### PR TITLE
Add `user` primitive to `ContainerOptionsBuilder`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -831,6 +831,15 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    pub fn user<'a>(&mut self, user: &str, group: impl Into<Option<&'a str>>) -> &mut Self {
+        let value = match group.into() {
+            Some(group) => format!("{}:{}", user, group),
+            None => user.to_string(),
+        };
+        self.params.insert("User", json!(value));
+        self
+    }
+
     pub fn cmd(
         &mut self,
         cmds: Vec<&str>,


### PR DESCRIPTION
## What did you implement:

Allow specifying the user to run a container as.

## How did you verify your change:

Modified `containercreate` example to overwrite the user of an image to `0:0` (where the image was configured to run as a non-root user) and checking that the container was run as root).

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Mention the new feature.