### PR TITLE
Chunks

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -122,7 +122,7 @@ impl Transport {
                     message: Self::get_error_message(&message_body).unwrap_or_else(|| {
                         status
                             .canonical_reason()
-                            .unwrap_or_else(|| "unknown error code")
+                            .unwrap_or("unknown error code")
                             .to_owned()
                     }),
                 })


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Add function for doing a stream POST and converting the HTTP chunks to JSON values.

HTTP chunks can contain one or more JSON values. This is currently handled in `Image::build` but not `Image::pull`.
When running with WSL2 and Docker Desktop, shiplift errors when pulling an image that already exists because Docker returns two JSON values in a single chunk.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

## How did you verify your change:
Ran the imagepull example with the same argument twice in succession.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Nothing